### PR TITLE
Add go module support to blacklist

### DIFF
--- a/blacklist/go.mod
+++ b/blacklist/go.mod
@@ -1,0 +1,5 @@
+module github.com/zmap/go-iptree/iptree/blacklist
+
+go 1.13
+
+require github.com/zmap/go-iptree v0.0.0-20200329195013-e20c2170cd25

--- a/blacklist/go.sum
+++ b/blacklist/go.sum
@@ -1,0 +1,4 @@
+github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 h1:Wi5Tgn8K+jDcBYL+dIMS1+qXYH2r7tpRAyBgqrWfQtw=
+github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56/go.mod h1:8BhOLuqtSuT5NZtZMwfvEibi09RO3u79uqfHZzfDTR4=
+github.com/zmap/go-iptree v0.0.0-20200329195013-e20c2170cd25 h1:7yjGJWT+Aonn7WjFauUqOPVf/SugPuGeOWgPQl6XBuQ=
+github.com/zmap/go-iptree v0.0.0-20200329195013-e20c2170cd25/go.mod h1:9vp0bxqozzQwcjBwenEXfKVq8+mYbwHkQ1NF9Ap0DMw=


### PR DESCRIPTION
So that the blacklist module can be referenced externally with go modules, create `go.mod` and `go.sum` in the blacklist directory as well.