### PR TITLE
Expose the SetCIDR functions from nradix.Tree

### DIFF
--- a/iptree/iptree.go
+++ b/iptree/iptree.go
@@ -42,6 +42,14 @@ func (i *IPTree) AddByString(ipcidr string, v interface{}) error {
 	return i.R.AddCIDR(ipcidr, v)
 }
 
+func (i *IPTree) Set(cidr *net.IPNet, v interface{}) error {
+	return i.R.SetCIDR(cidr.String(), v)
+}
+
+func (i *IPTree) SetByString(ipcidr string, v interface{}) error {
+	return i.R.SetCIDR(ipcidr, v)
+}
+
 func (i *IPTree) Get(ip net.IP) (interface{}, bool, error) {
 	v, err := i.R.FindCIDR(ip.String())
 	if v != nil {

--- a/iptree/iptree_test.go
+++ b/iptree/iptree_test.go
@@ -91,3 +91,21 @@ func TestFailingSubnet(t *testing.T) {
 		t.Error("Value within subset not correct")
 	}
 }
+
+func TestAddAndSetSameSubnet(t *testing.T) {
+	ip := New()
+	if err := ip.AddByString("1.0.0.0/24", 1); err != nil {
+		t.Errorf("error not expected: %v", err)
+	}
+	if err := ip.AddByString("1.0.0.0/24", 2); err == nil {
+		// Add checks first for existance, and will error if found
+		t.Error("error expected")
+	}
+	if err := ip.SetByString("1.0.0.0/24", 3); err != nil {
+		// Set should replace, therefore no error expected
+		t.Errorf("error not expected: %v", err)
+	}
+	if val, _, _ := ip.GetByString("1.0.0.0/24"); val.(int) != 3 {
+		t.Error("Value within subset not correct. Expected 3, got ", val)
+	}
+}


### PR DESCRIPTION
The `Add` functions will error if there already exists an entry for that Subnet. Having these `Set` functions to overwrite whatever is there would be useful for ZAnnotate